### PR TITLE
fixed typo on the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Local Development
 Clone the git repository, then
 ```
 bower install
-grunt install
-monogd
+npm install
+mongod
 grunt serve
 ```
 


### PR DESCRIPTION
A couple of the commands to start the local instance of firefly had a typo.

"grunt install" changed to "npm install".
"monogd" changed to "mongod".
