### PR TITLE
Change default scope from "devfest" to "wtm"

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -34,8 +34,9 @@ angular.module('fireflyApp', [
     $rootScope.all = window.location.search.indexOf("all") >= 0;
     $rootScope.prefix = window.location.hostname.replace(".gdg.events","");
 
-    if($rootScope.prefix == window.location.hostname )
-       $rootScope.prefix = "devfest";
+    if($rootScope.prefix == window.location.hostname ) {
+       $rootScope.prefix = "wtm";
+    }
 
     if($rootScope.prefix) {
       $http.jsonp('https://hub.gdgx.io/api/v1/tags/'+ $rootScope.prefix+'?callback=JSON_CALLBACK')


### PR DESCRIPTION
DevFest season is over so we should promote something else now.

This PR changes the default view when visiting http://gdg.events from "DevFest" to "WTM" (women tech makers).

![](https://lh6.googleusercontent.com/-hYX1ew5bOws/Unl119fXyYI/AAAAAAAAO6Y/852qqV8CK9A/w541-h889-no/SAM_0169.JPG)