### PR TITLE
Define the API key as a constant 

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -15,6 +15,7 @@ angular.module('fireflyApp', [
   'viewhead',
   'ja.qr'
 ])
+  .constant('GOOGLE_API_KEY', 'AIzaSyD7v04m_bTu-rcWtuaN3fTP9NBmjhB7lXg')
   .config(function ($routeProvider, $locationProvider, $mdThemingProvider) {
     $routeProvider
       .otherwise({
@@ -27,13 +28,13 @@ angular.module('fireflyApp', [
         .primaryPalette('grey')
         .accentPalette('indigo');
   })
-  .config(['uiGmapGoogleMapApiProvider', function (GoogleMapApi) {
-        GoogleMapApi.configure({
-            //    key: 'your api key',
+  .config(function (uiGmapGoogleMapApiProvider, GOOGLE_API_KEY) {
+        uiGmapGoogleMapApiProvider.configure({
+            key: GOOGLE_API_KEY,
             v: '3.17',
             libraries: 'weather,geometry,visualization'
         });
-  }])
+  })
   .run(function($rootScope, $geolocation, $http) {
 
     $rootScope.all = window.location.search.indexOf('all') >= 0;

--- a/client/app/shorturl/shorturl.controller.js
+++ b/client/app/shorturl/shorturl.controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('fireflyApp')
-  .controller('ShorturlEventCtrl', function ($scope, $http, $routeParams) {
+  .controller('ShorturlEventCtrl', function ($scope, $http, $routeParams, GOOGLE_API_KEY) {
         $scope.gdgeventsshorturl = '';
         var processEventData = function (data) {
             if (data.geo) {
@@ -20,7 +20,9 @@ angular.module('fireflyApp')
             }
             $scope.event = data;
 
-            $http.get('https://www.googleapis.com/plus/v1/people/' + $scope.event.chapter + '?fields=image&key=AIzaSyD7v04m_bTu-rcWtuaN3fTP9NBmjhB7lXg')
+            var chapterUrl = 'https://www.googleapis.com/plus/v1/people/' + $scope.event.chapter +
+              '?fields=image&key=' + GOOGLE_API_KEY;
+            $http.get(chapterUrl)
               .success(function (data) {
                 $scope.image = data.image.url.replace('sz=50', 'sz=70');
               }


### PR DESCRIPTION
and remove hard-coded API keys from JavaScript code.

This helps make #34 more easy to define in the README.