### PR TITLE
fix(qr): fix broken event QR codes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "moment-timezone": "0.3.1",
     "angular-linkify": "1.2.0",
     "angularjs-viewhead": "0.0.1",
-    "angular-qr": "latest"
+    "devintent-qr": "0.2.3"
   },
   "devDependencies": {
     "angular-mocks": "1.4.4"

--- a/client/index.html
+++ b/client/index.html
@@ -80,7 +80,7 @@
     <script src="bower_components/angular-linkify/angular-linkify.js"></script>
     <script src="bower_components/angularjs-viewhead/angularjs-viewhead.js"></script>
     <script src="bower_components/qrcode/lib/qrcode.js"></script>
-    <script src="bower_components/angular-qr/src/angular-qr.js"></script>
+    <script src="bower_components/devintent-qr/src/angular-qr.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -28,7 +28,7 @@ module.exports = function(config) {
       'client/bower_components/ngGeolocation/ngGeolocation.js',
       'client/bower_components/angular-linkify/angular-linkify.js',
       'client/bower_components/angularjs-viewhead/angularjs-viewhead.js',
-      'client/bower_components/angular-qr/src/angular-qr.js',
+      'client/bower_components/devintent-qr/src/angular-qr.js',
       'client/bower_components/lodash/lodash.js',
       'client/app/firefly.module.js',
       'client/app/firefly.config.js',


### PR DESCRIPTION
Use devintent-qr forked from angular-qr with fix for issue.

Fixes #57.