### PR TITLE
fix(geo): fix constant jumping back to current location on mobile and safari

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,14 +6,14 @@
     "es5-shim": "3.0.2",
     "jquery": "2.1.4",
     "bootstrap": "3.1.1",
-    "angular": "1.4.4",
-    "angular-animate": "1.4.4",
-    "angular-aria": "1.4.4",
-    "angular-resource": "1.4.4",
-    "angular-cookies": "1.4.4",
-    "angular-sanitize": "1.4.4",
-    "angular-route": "1.4.4",
-    "angular-material": "0.10.1",
+    "angular": "1.4.6",
+    "angular-animate": "1.4.6",
+    "angular-aria": "1.4.6",
+    "angular-resource": "1.4.6",
+    "angular-cookies": "1.4.6",
+    "angular-sanitize": "1.4.6",
+    "angular-route": "1.4.6",
+    "angular-material": "0.11.1",
     "angular-bootstrap": "0.13.3",
     "angular-google-chart": "0.0.11",
     "angular-google-maps": "2.1.5",
@@ -27,9 +27,9 @@
     "devintent-qr": "0.2.3"
   },
   "devDependencies": {
-    "angular-mocks": "1.4.4"
+    "angular-mocks": "1.4.6"
   },
   "resolutions": {
-    "angular": "1.4.4"
+    "angular": "1.4.6"
   }
 }

--- a/client/app/firefly.module.js
+++ b/client/app/firefly.module.js
@@ -34,9 +34,7 @@ angular.module('fireflyApp', ['ngCookies', 'ngResource', 'ngSanitize', 'ngRoute'
     });
 
   $rootScope.$on('$geolocation.position.changed', function(event, value) {
-      if (!$rootScope.geo ||
-        (value.coords.latitude !== $rootScope.latitude &&
-         value.coords.longitude !== $rootScope.longitude)) {
+      if (!$rootScope.geo) {
         $rootScope.geo = {
           latitude: value.coords.latitude,
           longitude: value.coords.longitude,

--- a/client/app/main/main.controller.js
+++ b/client/app/main/main.controller.js
@@ -5,10 +5,6 @@ angular.module('fireflyApp')
     $scope.domain = config.DOMAIN;
     $scope.nearEvent = undefined;
 
-    $rootScope.$watch('geo', function(geo) {
-      if (geo) { }
-    });
-
     $http.jsonp(config.HUB_IP + 'api/v1/events/stats?callback=JSON_CALLBACK')
       .success(function(data) {
         $scope.tags = data.upcoming_top_tags; // jshint ignore:line


### PR DESCRIPTION
Mobile GPS location updates frequently.
So constantly re-centering the map on each position update is not usable.
Require page refresh to center map at a new location.
Upgrade to angular-material 0.11.1 and angular to 1.4.6.

Fixes #63.