### PR TITLE
fix(footer): ClipboardEvent constructor throws exceptions

### DIFF
--- a/client/components/footer/footer.directive.js
+++ b/client/components/footer/footer.directive.js
@@ -15,14 +15,6 @@ angular.module('fireflyApp')
         scope.url = document.URL;
         scope.convertHex = convertHex;
 
-        scope.copyUrl = function(e) {
-          var clip = new ClipboardEvent('copy');
-          clip.clipboardData.setData('text/plain', 'test');
-          clip.preventDefault();
-
-          e.target.dispatchEvent(clip);
-        };
-
         /**
          * @param hex color
          * @param opacity percentage

--- a/client/components/footer/footer.html
+++ b/client/components/footer/footer.html
@@ -1,13 +1,7 @@
 <div class="footer" layout-fill ng-style="{'background-color': convertHex(tag.color, 20)}">
-    <div class="pull-right form-inline">
-     	<input type="text" ng-model="url" class="form-control" readonly style="height:24px">
-      <md-button ng-click="copyUrl($event)" class="md-icon-button md-accent">
-        <md-icon aria-label="Copy URL to Clipboard">link</md-icon>
-        <md-tooltip md-direction="top">Copy URL to Clipboard</md-tooltip>
-      </md-button>
-    </div>
-	<div class="pull-left">
-	    <p>&copy; 2015 <a href="https://plus.google.com/+GDGXProject/">GDG[x]</a> - <a href="https://github.com/gdg-x/firefly/">Project Firefly</a></p>
-	    <i>GDG[x] is an independent group; our activities and the opinions expressed on this Page should in no way be linked to Google, the corporation.</i>
-    </div>
+    <p>&copy; 2015 <a href="https://plus.google.com/+GDGXProject/">GDG[x]</a> -
+      <a href="https://github.com/gdg-x/firefly/">Project Firefly</a></p>
+    <i>GDG[x] is an independent group; our activities and the opinions expressed on this
+      Page should in no way be linked to Google, the corporation.
+    </i>
 </div>


### PR DESCRIPTION
Remove Clipboard usage as the API is too unstable across browsers and the use case is not compelling.
Remove extraneous Bootstrap classes.