### PR TITLE
Add page for app invite dynamic links

### DIFF
--- a/client/app/firefly.config.js
+++ b/client/app/firefly.config.js
@@ -15,7 +15,7 @@ angular.module('fireflyApp')
         controller: 'MainCtrl',
         controllerAs: 'vm'
       })
-      .when('/site/app-invite', {
+      .when('/invite', {
         templateUrl: 'app/site/app-invite.html'
       })
       .when('/:tag/events', {

--- a/client/app/firefly.config.js
+++ b/client/app/firefly.config.js
@@ -15,6 +15,9 @@ angular.module('fireflyApp')
         controller: 'MainCtrl',
         controllerAs: 'vm'
       })
+      .when('/site/app-invite', {
+        templateUrl: 'app/site/app-invite.html'
+      })
       .when('/:tag/events', {
         templateUrl: 'app/main/eventList.html',
         controller: 'MainCtrl',

--- a/client/app/site/app-invite.html
+++ b/client/app/site/app-invite.html
@@ -1,0 +1,18 @@
+<div layout="column" layout-fill>
+  <view-title>GDG App Invite</view-title>
+  <div layout layout-margin layout-wrap>
+    <p>
+      Hello, you have been invited to use the GDG app!
+    </p>
+    <p>
+      Find out more about it now or browse the GDG events around the world at <a
+      href="https://gdg.events">gdg.events</a>.
+    </p>
+  </div>
+  <div layout layout-margin layout-wrap>
+    <a href='https://play.google.com/store/apps/details?id=org.gdg.frisbee.android&utm_source=global_co&utm_medium=prtnr&utm_content=Mar2515&utm_campaign=PartBadge&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' width="200"/></a>
+  </div>
+  <div layout layout-margin layout-wrap>
+    <small>Google Play and the Google Play logo are trademarks of Google Inc.</small>
+  </div>
+</div>


### PR DESCRIPTION
Adds a static site to invite users to download the GDG Android app.

![app invite page](https://cloud.githubusercontent.com/assets/1449049/18780051/f8c43a82-817b-11e6-9abf-e1dffd686a6d.png)

Fixes #103 